### PR TITLE
[WIP] Feature/test x cdp keeper draw

### DIFF
--- a/x/cdp/keeper/draw_test.go
+++ b/x/cdp/keeper/draw_test.go
@@ -137,7 +137,9 @@ func (suite *DrawTestSuite) TestAddRepayPrincipalFees() {
 	err := suite.keeper.AddCdp(suite.ctx, suite.addrs[2], c("xrp", 1000000000000), c("usdx", 100000000000), "xrp-a")
 	suite.NoError(err)
 	suite.ctx = suite.ctx.WithBlockTime(suite.ctx.BlockTime().Add(time.Minute * 10))
-	err = suite.keeper.UpdateFeesForAllCdps(suite.ctx, "xrp-a")
+	err = suite.keeper.AccumulateInterest(suite.ctx, "xrp-a")
+	suite.NoError(err)
+	err = suite.keeper.SynchronizeInterestForRiskyCdps(suite.ctx, sdk.Int{}, sdk.MaxSortableDec, "xrp-a")
 	suite.NoError(err)
 	err = suite.keeper.AddPrincipal(suite.ctx, suite.addrs[2], "xrp-a", c("usdx", 10000000))
 	suite.NoError(err)
@@ -156,7 +158,9 @@ func (suite *DrawTestSuite) TestAddRepayPrincipalFees() {
 	suite.NoError(err)
 
 	suite.ctx = suite.ctx.WithBlockTime(suite.ctx.BlockTime().Add(time.Second * 31536000)) // move forward one year in time
-	err = suite.keeper.UpdateFeesForAllCdps(suite.ctx, "xrp-a")
+	err = suite.keeper.AccumulateInterest(suite.ctx, "xrp-a")
+	suite.NoError(err)
+	err = suite.keeper.SynchronizeInterestForRiskyCdps(suite.ctx, sdk.Int{}, sdk.MaxSortableDec, "xrp-a")
 	suite.NoError(err)
 	err = suite.keeper.AddPrincipal(suite.ctx, suite.addrs[2], "xrp-a", c("usdx", 100000000))
 	suite.NoError(err)


### PR DESCRIPTION
@KimuraYu45z cc: @Senna46 

以下リンクの箇所のエラー解決に詰まっています。質問させてください。

jpyx実装ファイル
https://github.com/lcnem/jpyx/blob/09410aa405427e48cbbb786a335e1d2633b928c7/x/cdp/keeper/draw_test.go#L140

参考元kavaファイル
https://github.com/Kava-Labs/kava/blob/fabeee93cc91bdb9de5d4d1865dfe8bca9ef8a55/x/cdp/keeper/draw_test.go

エラー

```
suite.keeper.UpdateFeesForAllCdps undefined (type "github.com/lcnem/jpyx/x/cdp/keeper".Keeper has no field or method UpdateFeesForAllCdps)compilerMissingFieldOrMethod
```

kavaでは、`x/cdp/keeper/fees.go`にてその関数が定義されていたのですが、jpyxではそのファイルがなく、別のところに同様の機能の関数が無いか探したのですが見つけられず、詰まっているという感じです。

kava 参考リンク
- バージョンv0.11.1
  - https://github.com/Kava-Labs/kava/releases/tag/v0.11.1
- バージョンv0.11.1時点でのmasterブランチ
  - https://github.com/Kava-Labs/kava/tree/fabeee93cc91bdb9de5d4d1865dfe8bca9ef8a55
