### PR TITLE
feat: auction types genesis

### DIFF
--- a/x/auction/types/genesis_test.go
+++ b/x/auction/types/genesis_test.go
@@ -1,0 +1,47 @@
+package types
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	sdk "github.com/cosmos/cosmos-sdk/types"
+)
+
+var testCoin = sdk.NewInt64Coin("test", 20)
+
+func TestGenesisState_Validate(t *testing.T) {
+	testCases := []struct {
+		name       string
+		nextID     uint64
+		auctions   GenesisAuctions
+		expectPass bool
+	}{
+		{"default", DefaultGenesisState().NextAuctionID, DefaultGenesisState().Auctions, true},
+		{"invalid next ID", 54, GenesisAuctions{SurplusAuction{BaseAuction{ID: 105}}}, false},
+		{
+			"repeated ID",
+			1000,
+			GenesisAuctions{
+				SurplusAuction{BaseAuction{ID: 105}},
+				DebtAuction{BaseAuction{ID: 105}, testCoin},
+			},
+			false,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			gs := NewGenesisState(tc.nextID, DefaultParams(), tc.auctions)
+
+			err := gs.Validate()
+
+			if tc.expectPass {
+				require.NoError(t, err)
+			} else {
+				require.Error(t, err)
+			}
+		})
+	}
+
+}

--- a/x/auction/types/genesis_test.go
+++ b/x/auction/types/genesis_test.go
@@ -6,16 +6,12 @@ import (
 	"github.com/stretchr/testify/require"
 
 	sdk "github.com/cosmos/cosmos-sdk/types"
-
-	auctiontypes "github.com/lcnem/jpyx/x/auction/types"
 )
 
 var testCoin = sdk.NewInt64Coin("test", 20)
 
 // AuctionをAny型からAuction型に変換
-var unpackAuctions, _ = auctiontypes.unpackAuctions(DefaultGenesis().Auctions)
-var unpackSurplusAuction, _ = auctiontypes.unpackAuctions(SurplusAuction)
-var unpackDebtAuction, _ = auctiontypes.unpackAuctions(DebtAuction)
+var unpackAuctions, _ = UnpackGenesisAuctions(DefaultGenesis().Auctions)
 
 func TestGenesisState_Validate(t *testing.T) {
 	testCases := []struct {
@@ -27,15 +23,15 @@ func TestGenesisState_Validate(t *testing.T) {
 		// {"default", DefaultGenesis().NextAuctionId, DefaultGenesis().Auctions, true},
 		// {"invalid next ID", 54, GenesisAuctions{SurplusAuction{BaseAuction{ID: 105}}}, false},
 		{"default", DefaultGenesis().NextAuctionId, unpackAuctions, true},
-		{"invalid next ID", 54, GenesisAuctions{unpackSurplusAuction{BaseAuction{Id: 105}}}, false},
+		{"invalid next ID", 54, GenesisAuctions{&SurplusAuction{BaseAuction{Id: 105}}}, false},
 		{
 			"repeated ID",
 			1000,
 			GenesisAuctions{
 				// SurplusAuction{BaseAuction{ID: 105}},
 				// DebtAuction{BaseAuction{ID: 105}, testCoin},
-				unpackSurplusAuction{BaseAuction{Id: 105}},
-				unpackDebtAuction{BaseAuction{Id: 105}, testCoin},
+				&SurplusAuction{BaseAuction{Id: 105}},
+				&DebtAuction{BaseAuction{Id: 105}, testCoin},
 			},
 			false,
 		},
@@ -45,7 +41,7 @@ func TestGenesisState_Validate(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			// gs := NewGenesisState(tc.nextID, DefaultParams(), tc.auctions)
 			// NewGenesisStateの引数tc.acutionをAny型に変換
-			packAuction, _ := auctiontypes.PackGenesisAuctions(tc.auctions)
+			packAuction, _ := PackGenesisAuctions(tc.auctions)
 			gs := NewGenesisState(tc.nextID, DefaultParams(), packAuction)
 
 			err := gs.Validate()

--- a/x/auction/types/genesis_test.go
+++ b/x/auction/types/genesis_test.go
@@ -6,9 +6,16 @@ import (
 	"github.com/stretchr/testify/require"
 
 	sdk "github.com/cosmos/cosmos-sdk/types"
+
+	auctiontypes "github.com/lcnem/jpyx/x/auction/types"
 )
 
 var testCoin = sdk.NewInt64Coin("test", 20)
+
+// AuctionをAny型からAuction型に変換
+var unpackAuctions, _ = auctiontypes.unpackAuctions(DefaultGenesis().Auctions)
+var unpackSurplusAuction, _ = auctiontypes.unpackAuctions(SurplusAuction)
+var unpackDebtAuction, _ = auctiontypes.unpackAuctions(DebtAuction)
 
 func TestGenesisState_Validate(t *testing.T) {
 	testCases := []struct {
@@ -17,14 +24,18 @@ func TestGenesisState_Validate(t *testing.T) {
 		auctions   GenesisAuctions
 		expectPass bool
 	}{
-		{"default", DefaultGenesisState().NextAuctionID, DefaultGenesisState().Auctions, true},
-		{"invalid next ID", 54, GenesisAuctions{SurplusAuction{BaseAuction{ID: 105}}}, false},
+		// {"default", DefaultGenesis().NextAuctionId, DefaultGenesis().Auctions, true},
+		// {"invalid next ID", 54, GenesisAuctions{SurplusAuction{BaseAuction{ID: 105}}}, false},
+		{"default", DefaultGenesis().NextAuctionId, unpackAuctions, true},
+		{"invalid next ID", 54, GenesisAuctions{unpackSurplusAuction{BaseAuction{Id: 105}}}, false},
 		{
 			"repeated ID",
 			1000,
 			GenesisAuctions{
-				SurplusAuction{BaseAuction{ID: 105}},
-				DebtAuction{BaseAuction{ID: 105}, testCoin},
+				// SurplusAuction{BaseAuction{ID: 105}},
+				// DebtAuction{BaseAuction{ID: 105}, testCoin},
+				unpackSurplusAuction{BaseAuction{Id: 105}},
+				unpackDebtAuction{BaseAuction{Id: 105}, testCoin},
 			},
 			false,
 		},
@@ -32,7 +43,10 @@ func TestGenesisState_Validate(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			gs := NewGenesisState(tc.nextID, DefaultParams(), tc.auctions)
+			// gs := NewGenesisState(tc.nextID, DefaultParams(), tc.auctions)
+			// NewGenesisStateの引数tc.acutionをAny型に変換
+			packAuction, _ := auctiontypes.PackGenesisAuctions(tc.auctions)
+			gs := NewGenesisState(tc.nextID, DefaultParams(), packAuction)
 
 			err := gs.Validate()
 


### PR DESCRIPTION
typesの方のgenesis_test.goも作成しました。

- Auction型を要求されている3変数をUnpack
- Any型を要求されている1変数をPack

@KimuraYu45z @YasunoriMATSUOKA 
レビューお願いします。
VSCode上でインポートの`auctiontypes "github.com/lcnem/jpyx/x/auction/types"`がエラーとなっているのですが、原因わかりますでしょうか？
私の環境だけの問題だったらいいのですが、今回、PackとUnpackを使用するにあたり、インポートに追加しています。