### PR TITLE
fix: legacy amino to proto

### DIFF
--- a/app/test_common.go
+++ b/app/test_common.go
@@ -20,6 +20,7 @@ import (
 	authtypes "github.com/cosmos/cosmos-sdk/x/auth/types"
 	banktypes "github.com/cosmos/cosmos-sdk/x/bank/types"
 
+	codec "github.com/cosmos/cosmos-sdk/codec"
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	authkeeper "github.com/cosmos/cosmos-sdk/x/auth/keeper"
 	bankkeeper "github.com/cosmos/cosmos-sdk/x/bank/keeper"
@@ -61,7 +62,7 @@ func NewTestApp() TestApp {
 	config.SetBech32PrefixForAccount(AccountAddressPrefix, AccountPubKeyPrefix)
 	config.SetBech32PrefixForValidator(ValidatorAddressPrefix, ValidatorPubKeyPrefix)
 	config.SetBech32PrefixForConsensusNode(ConsNodeAddressPrefix, ConsNodePubKeyPrefix)
-	config.Seal()
+	// config.Seal()
 
 	db := tmdb.NewMemDB()
 
@@ -107,8 +108,8 @@ func (tApp TestApp) InitializeFromGenesisStates(genesisStates ...GenesisState) T
 	}
 
 	// Initialize the chain
-	// stateBytes, err := codec.MarshalJSONIndent(tApp.cdc, genesisState)
-	stateBytes, err := json.MarshalIndent(genesisState, "", "  ")
+	stateBytes, err := codec.MarshalJSONIndent(tApp.cdc, genesisState)
+	// stateBytes, err := json.MarshalIndent(genesisState, "", "  ")
 	if err != nil {
 		panic(err)
 	}
@@ -187,7 +188,7 @@ func (tApp TestApp) CheckBalance(t *testing.T, ctx sdk.Context, owner sdk.AccAdd
 }
 
 // Create a new auth genesis state from some addresses and coins. The state is returned marshalled into a map.
-func NewAuthGenState(addresses []sdk.AccAddress, coins []sdk.Coins) GenesisState {
+func NewAuthGenState(tApp TestApp, addresses []sdk.AccAddress, coins []sdk.Coins) GenesisState {
 	// Create GenAccounts
 	accounts := authtypes.GenesisAccounts{}
 	for i := range addresses {
@@ -200,7 +201,8 @@ func NewAuthGenState(addresses []sdk.AccAddress, coins []sdk.Coins) GenesisState
 	for i := range addresses {
 		bankGenesis.Balances = append(bankGenesis.Balances, banktypes.Balance{Address: addresses[i].String(), Coins: coins[i]})
 	}
-	return GenesisState{authtypes.ModuleName: authtypes.ModuleCdc.MustMarshalJSON(authGenesis), banktypes.ModuleName: banktypes.ModuleCdc.MustMarshalJSON(bankGenesis)}
+	// return GenesisState{authtypes.ModuleName: authtypes.ModuleCdc.MustMarshalJSON(authGenesis), banktypes.ModuleName: banktypes.ModuleCdc.MustMarshalJSON(bankGenesis)}
+	return GenesisState{authtypes.ModuleName: tApp.appCodec.MustMarshalJSON(authGenesis), banktypes.ModuleName: tApp.appCodec.MustMarshalJSON(bankGenesis)}
 }
 
 // GeneratePrivKeyAddressPairsFromRand generates (deterministically) a total of n secp256k1 private keys and addresses.

--- a/x/auction/abci_test.go
+++ b/x/auction/abci_test.go
@@ -37,7 +37,7 @@ func TestKeeper_BeginBlocker(t *testing.T) {
 		// 	auth.NewBaseAccount(buyer, cs(c("token1", 100), c("token2", 100)), nil, 0, 0),
 		// 	sellerAcc,
 		// }),
-		app.NewAuthGenState([]sdk.AccAddress{buyer, sellerAddr}, []sdk.Coins{cs(c("token1", 100), c("token2", 100)), sdk.Coins{}}),
+		app.NewAuthGenState(tApp, []sdk.AccAddress{buyer, sellerAddr}, []sdk.Coins{cs(c("token1", 100), c("token2", 100)), sdk.Coins{}}),
 	)
 
 	keeper := tApp.GetAuctionKeeper()

--- a/x/auction/keeper/auctions_test.go
+++ b/x/auction/keeper/auctions_test.go
@@ -34,7 +34,7 @@ func TestSurplusAuctionBasic(t *testing.T) {
 		// 	authtypes.NewBaseAccount(buyer, cs(c("token1", 100), c("token2", 100)), nil, 0, 0),
 		// 	sellerAcc,
 		// }),
-		app.NewAuthGenState([]sdk.AccAddress{buyer, sellerAddr}, []sdk.Coins{cs(c("token1", 100), c("token2", 100)), sdk.Coins{}}),
+		app.NewAuthGenState(tApp, []sdk.AccAddress{buyer, sellerAddr}, []sdk.Coins{cs(c("token1", 100), c("token2", 100)), sdk.Coins{}}),
 	)
 
 	keeper := tApp.GetAuctionKeeper()
@@ -81,7 +81,7 @@ func TestDebtAuctionBasic(t *testing.T) {
 		// 	authtypes.NewBaseAccount(seller, cs(c("token1", 100), c("token2", 100)), nil, 0, 0),
 		// 	buyerAcc,
 		// }),
-		app.NewAuthGenState([]sdk.AccAddress{seller, buyerAddr}, []sdk.Coins{cs(c("token1", 100), c("token2", 100)), sdk.Coins{}}),
+		app.NewAuthGenState(tApp, []sdk.AccAddress{seller, buyerAddr}, []sdk.Coins{cs(c("token1", 100), c("token2", 100)), sdk.Coins{}}),
 	)
 	keeper := tApp.GetAuctionKeeper()
 
@@ -123,7 +123,7 @@ func TestDebtAuctionDebtRemaining(t *testing.T) {
 		// 	authtypes.NewBaseAccount(seller, cs(c("token1", 100), c("token2", 100)), nil, 0, 0),
 		// 	buyerAcc,
 		// }),
-		app.NewAuthGenState([]sdk.AccAddress{seller, buyerAddr}, []sdk.Coins{cs(c("token1", 100), c("token2", 100)), sdk.Coins{}}),
+		app.NewAuthGenState(tApp, []sdk.AccAddress{seller, buyerAddr}, []sdk.Coins{cs(c("token1", 100), c("token2", 100)), sdk.Coins{}}),
 	)
 	keeper := tApp.GetAuctionKeeper()
 
@@ -172,10 +172,10 @@ func TestCollateralAuctionBasic(t *testing.T) {
 		// 	authtypes.NewBaseAccount(returnAddrs[2], cs(c("token1", 100), c("token2", 100)), nil, 0, 0),
 		// 	sellerAcc,
 		// }),
-		app.NewAuthGenState([]sdk.AccAddress{buyer, sellerAddr}, []sdk.Coins{cs(c("token1", 100), c("token2", 100)), sdk.Coins{}}),
-		app.NewAuthGenState([]sdk.AccAddress{returnAddrs[0], sellerAddr}, []sdk.Coins{cs(c("token1", 100), c("token2", 100)), sdk.Coins{}}),
-		app.NewAuthGenState([]sdk.AccAddress{returnAddrs[1], sellerAddr}, []sdk.Coins{cs(c("token1", 100), c("token2", 100)), sdk.Coins{}}),
-		app.NewAuthGenState([]sdk.AccAddress{returnAddrs[2], sellerAddr}, []sdk.Coins{cs(c("token1", 100), c("token2", 100)), sdk.Coins{}}),
+		app.NewAuthGenState(tApp, []sdk.AccAddress{buyer, sellerAddr}, []sdk.Coins{cs(c("token1", 100), c("token2", 100)), sdk.Coins{}}),
+		app.NewAuthGenState(tApp, []sdk.AccAddress{returnAddrs[0], sellerAddr}, []sdk.Coins{cs(c("token1", 100), c("token2", 100)), sdk.Coins{}}),
+		app.NewAuthGenState(tApp, []sdk.AccAddress{returnAddrs[1], sellerAddr}, []sdk.Coins{cs(c("token1", 100), c("token2", 100)), sdk.Coins{}}),
+		app.NewAuthGenState(tApp, []sdk.AccAddress{returnAddrs[2], sellerAddr}, []sdk.Coins{cs(c("token1", 100), c("token2", 100)), sdk.Coins{}}),
 	)
 	keeper := tApp.GetAuctionKeeper()
 
@@ -237,10 +237,10 @@ func TestCollateralAuctionDebtRemaining(t *testing.T) {
 		// 	authtypes.NewBaseAccount(returnAddrs[2], cs(c("token1", 100), c("token2", 100)), nil, 0, 0),
 		// 	sellerAcc,
 		// }),
-		app.NewAuthGenState([]sdk.AccAddress{buyer, sellerAddr}, []sdk.Coins{cs(c("token1", 100), c("token2", 100)), sdk.Coins{}}),
-		app.NewAuthGenState([]sdk.AccAddress{returnAddrs[0], sellerAddr}, []sdk.Coins{cs(c("token1", 100), c("token2", 100)), sdk.Coins{}}),
-		app.NewAuthGenState([]sdk.AccAddress{returnAddrs[1], sellerAddr}, []sdk.Coins{cs(c("token1", 100), c("token2", 100)), sdk.Coins{}}),
-		app.NewAuthGenState([]sdk.AccAddress{returnAddrs[2], sellerAddr}, []sdk.Coins{cs(c("token1", 100), c("token2", 100)), sdk.Coins{}}),
+		app.NewAuthGenState(tApp, []sdk.AccAddress{buyer, sellerAddr}, []sdk.Coins{cs(c("token1", 100), c("token2", 100)), sdk.Coins{}}),
+		app.NewAuthGenState(tApp, []sdk.AccAddress{returnAddrs[0], sellerAddr}, []sdk.Coins{cs(c("token1", 100), c("token2", 100)), sdk.Coins{}}),
+		app.NewAuthGenState(tApp, []sdk.AccAddress{returnAddrs[1], sellerAddr}, []sdk.Coins{cs(c("token1", 100), c("token2", 100)), sdk.Coins{}}),
+		app.NewAuthGenState(tApp, []sdk.AccAddress{returnAddrs[2], sellerAddr}, []sdk.Coins{cs(c("token1", 100), c("token2", 100)), sdk.Coins{}}),
 	)
 	keeper := tApp.GetAuctionKeeper()
 
@@ -392,7 +392,7 @@ func TestCloseAuction(t *testing.T) {
 		// 	authtypes.NewBaseAccount(buyer, cs(c("token1", 100), c("token2", 100)), nil, 0, 0),
 		// 	sellerAcc,
 		// }),
-		app.NewAuthGenState([]sdk.AccAddress{buyer, sellerAddr}, []sdk.Coins{cs(c("token1", 100), c("token2", 100)), sdk.Coins{}}),
+		app.NewAuthGenState(tApp, []sdk.AccAddress{buyer, sellerAddr}, []sdk.Coins{cs(c("token1", 100), c("token2", 100)), sdk.Coins{}}),
 	)
 	keeper := tApp.GetAuctionKeeper()
 
@@ -426,7 +426,7 @@ func TestCloseExpiredAuctions(t *testing.T) {
 		// 	authtypes.NewBaseAccount(buyer, cs(c("token1", 100), c("token2", 100)), nil, 0, 0),
 		// 	sellerAcc,
 		// }),
-		app.NewAuthGenState([]sdk.AccAddress{buyer, sellerAddr}, []sdk.Coins{cs(c("token1", 100), c("token2", 100)), sdk.Coins{}}),
+		app.NewAuthGenState(tApp, []sdk.AccAddress{buyer, sellerAddr}, []sdk.Coins{cs(c("token1", 100), c("token2", 100)), sdk.Coins{}}),
 	)
 	keeper := tApp.GetAuctionKeeper()
 

--- a/x/cdp/abci_test.go
+++ b/x/cdp/abci_test.go
@@ -50,7 +50,7 @@ func (suite *ModuleTestSuite) SetupTest() {
 	_, addrs := app.GeneratePrivKeyAddressPairs(100)
 
 	authGS := app.NewAuthGenState(
-		addrs, coins)
+		tApp, addrs, coins)
 	tApp.InitializeFromGenesisStates(
 		authGS,
 		NewPricefeedGenStateMulti(),
@@ -77,7 +77,7 @@ func (suite *ModuleTestSuite) createCdps() {
 	}
 
 	authGS := app.NewAuthGenState(
-		addrs, coins)
+		tApp, addrs, coins)
 	tApp.InitializeFromGenesisStates(
 		authGS,
 		NewPricefeedGenStateMulti(),

--- a/x/cdp/keeper/auctions_test.go
+++ b/x/cdp/keeper/auctions_test.go
@@ -30,7 +30,7 @@ type AuctionTestSuite struct {
 func (suite *AuctionTestSuite) SetupTest() {
 	tApp := app.NewTestApp()
 	taddr := sdk.AccAddress(crypto.AddressHash([]byte("KavaTestUser1")))
-	authGS := app.NewAuthGenState([]sdk.AccAddress{taddr}, []sdk.Coins{cs(c("usdx", 21000000000))})
+	authGS := app.NewAuthGenState(tApp, []sdk.AccAddress{taddr}, []sdk.Coins{cs(c("usdx", 21000000000))})
 	ctx := tApp.NewContext(true, tmproto.Header{Height: 1, Time: tmtime.Now()})
 	tApp.InitializeFromGenesisStates(
 		authGS,

--- a/x/cdp/keeper/deposit_test.go
+++ b/x/cdp/keeper/deposit_test.go
@@ -30,6 +30,7 @@ func (suite *DepositTestSuite) SetupTest() {
 	ctx := tApp.NewContext(true, tmproto.Header{Height: 1, Time: tmtime.Now()})
 	_, addrs := app.GeneratePrivKeyAddressPairs(10)
 	authGS := app.NewAuthGenState(
+		tApp,
 		addrs[0:2],
 		[]sdk.Coins{
 			cs(c("xrp", 500000000), c("btc", 500000000)),

--- a/x/cdp/keeper/draw_test.go
+++ b/x/cdp/keeper/draw_test.go
@@ -31,6 +31,7 @@ func (suite *DrawTestSuite) SetupTest() {
 	ctx := tApp.NewContext(true, tmproto.Header{Height: 1, Time: tmtime.Now()})
 	_, addrs := app.GeneratePrivKeyAddressPairs(3)
 	authGS := app.NewAuthGenState(
+		tApp,
 		addrs,
 		[]sdk.Coins{
 			cs(c("xrp", 500000000), c("btc", 500000000), c("usdx", 10000000000)),

--- a/x/cdp/keeper/keeper_bench_test.go
+++ b/x/cdp/keeper/keeper_bench_test.go
@@ -79,7 +79,7 @@ func createCdps(n int) (app.TestApp, sdk.Context, keeper.Keeper) {
 		coins = append(coins, cs(c("btc", 100000000)))
 	}
 	authGS := app.NewAuthGenState(
-		addrs, coins)
+		tApp, addrs, coins)
 	tApp.InitializeFromGenesisStates(
 		authGS,
 		NewPricefeedGenStateMulti(),
@@ -130,7 +130,7 @@ func BenchmarkCdpCreation(b *testing.B) {
 		coins = append(coins, cs(c("btc", 100000000)))
 	}
 	authGS := app.NewAuthGenState(
-		addrs, coins)
+		tApp, addrs, coins)
 	tApp.InitializeFromGenesisStates(
 		authGS,
 		NewPricefeedGenStateMulti(),

--- a/x/cdp/keeper/seize_test.go
+++ b/x/cdp/keeper/seize_test.go
@@ -49,7 +49,7 @@ func (suite *SeizeTestSuite) SetupTest() {
 	_, addrs := app.GeneratePrivKeyAddressPairs(100)
 
 	authGS := app.NewAuthGenState(
-		addrs, coins)
+		tApp, addrs, coins)
 	tApp.InitializeFromGenesisStates(
 		authGS,
 		NewPricefeedGenStateMulti(),
@@ -76,7 +76,7 @@ func (suite *SeizeTestSuite) createCdps() {
 	}
 
 	authGS := app.NewAuthGenState(
-		addrs, coins)
+		tApp, addrs, coins)
 	tApp.InitializeFromGenesisStates(
 		authGS,
 		NewPricefeedGenStateMulti(),

--- a/x/incentive/keeper/integration_test.go
+++ b/x/incentive/keeper/integration_test.go
@@ -181,7 +181,7 @@ func NewHardGenStateMulti() app.GenesisState {
 }
 */
 
-func NewAuthGenState(addresses []sdk.AccAddress, coins sdk.Coins) app.GenesisState {
+func NewAuthGenState(tApp app.TestApp, addresses []sdk.AccAddress, coins sdk.Coins) app.GenesisState {
 	coinsList := []sdk.Coins{}
 	for range addresses {
 		coinsList = append(coinsList, coins)
@@ -198,7 +198,7 @@ func NewAuthGenState(addresses []sdk.AccAddress, coins sdk.Coins) app.GenesisSta
 		)
 	}
 
-	return app.NewAuthGenState(addresses, coinsList)
+	return app.NewAuthGenState(tApp, addresses, coinsList)
 }
 
 func NewStakingGenesisState() app.GenesisState {
@@ -220,7 +220,7 @@ func (suite *KeeperTestSuite) SetupWithGenState() {
 	ctx := tApp.NewContext(true, tmproto.Header{Height: 1, Time: tmtime.Now()})
 
 	tApp.InitializeFromGenesisStates(
-		NewAuthGenState(allAddrs, cs(c("ukava", 5_000_000))),
+		NewAuthGenState(tApp, allAddrs, cs(c("ukava", 5_000_000))),
 		NewStakingGenesisState(),
 		NewPricefeedGenStateMulti(),
 		NewCDPGenStateMulti(),

--- a/x/incentive/keeper/payout_test.go
+++ b/x/incentive/keeper/payout_test.go
@@ -745,6 +745,7 @@ func (suite *KeeperTestSuite) SetupWithAccountState() {
 	ctx := tApp.NewContext(true, tmproto.Header{Height: 1, Time: time.Unix(100, 0)})
 	_, addrs := app.GeneratePrivKeyAddressPairs(4)
 	authGS := app.NewAuthGenState(
+		tApp, 
 		addrs,
 		[]sdk.Coins{
 			cs(c("ukava", 400)),

--- a/x/jsmndist/keeper/mint_test.go
+++ b/x/jsmndist/keeper/mint_test.go
@@ -44,7 +44,7 @@ func (suite *KeeperTestSuite) SetupTest() {
 	_, addrs := app.GeneratePrivKeyAddressPairs(1)
 	coins := []sdk.Coins{sdk.NewCoins(sdk.NewCoin("ukava", sdk.NewInt(1000000000000)))}
 	authGS := app.NewAuthGenState(
-		addrs, coins)
+		tApp, addrs, coins)
 
 	ctx := tApp.NewContext(true, tmproto.Header{Height: 1, Time: tmtime.Now()})
 


### PR DESCRIPTION
`authtypes.ModuleCdc.MustMarshalJSON`を`tApp.appCodec.MustMarshalJSON`に変更
レガシーのAminoからprotoへ

引数にtAppを追加