### PR TITLE
test: fix x/cdp/keeper/draw 

### DIFF
--- a/x/cdp/keeper/draw_test.go
+++ b/x/cdp/keeper/draw_test.go
@@ -186,7 +186,8 @@ func (suite *DrawTestSuite) TestModuleAccountFailure() {
 		ctx := suite.ctx.WithBlockHeader(suite.ctx.BlockHeader())
 		ak := suite.app.GetAccountKeeper()
 		acc := ak.GetModuleAccount(ctx, types.ModuleName)
-		ak.RemoveAccount(ctx, acc)
+		bk := suite.app.GetBankKeeper()
+		bk.BurnCoins(ctx, types.ModuleName, bk.GetAllBalances(ctx, acc.GetAddress()))
 		suite.keeper.RepayPrincipal(ctx, suite.addrs[0], "xrp-a", c("usdx", 10000000))
 	})
 }

--- a/x/cdp/keeper/draw_test.go
+++ b/x/cdp/keeper/draw_test.go
@@ -129,11 +129,12 @@ func (suite *DrawTestSuite) TestRepayPrincipalOverpay() {
 	ak := suite.app.GetAccountKeeper()
 	sk := suite.app.GetBankKeeper()
 	acc := ak.GetAccount(suite.ctx, suite.addrs[0])
-	suite.Equal(i(10000000000), sk.GetBalance(suite.ctx, acc.GetAddress(), "usdx"))
+	suite.Equal(i(10000000000), sk.GetBalance(suite.ctx, acc.GetAddress(), "usdx").Amount)
 	_, found := suite.keeper.GetCdp(suite.ctx, "xrp-a", 1)
 	suite.False(found)
 }
 
+/* Note: This test existed only on v0.11.1. On v0.13.0, this test is removed. So, I guess this test is unnecessary.
 func (suite *DrawTestSuite) TestAddRepayPrincipalFees() {
 	err := suite.keeper.AddCdp(suite.ctx, suite.addrs[2], c("xrp", 1000000000000), c("usdx", 100000000000), "xrp-a")
 	suite.NoError(err)
@@ -168,6 +169,7 @@ func (suite *DrawTestSuite) TestAddRepayPrincipalFees() {
 	t, _ = suite.keeper.GetCdp(suite.ctx, "xrp-a", uint64(3))
 	suite.Equal(c("usdx", 5000000), t.AccumulatedFees)
 }
+*/
 
 func (suite *DrawTestSuite) TestPricefeedFailure() {
 	ctx := suite.ctx.WithBlockTime(suite.ctx.BlockTime().Add(time.Hour * 2))


### PR DESCRIPTION
@KimuraYu45z cc: @Senna46 @Tomosuke0930 

以下のテストがPassできず、修正方針迷っています。

https://github.com/lcnem/jpyx/blob/ae2faae26866b90cf6191dcfa2713bb3855e0d21/x/cdp/keeper/draw_test.go#L184

テスト実行結果

```
Running tool: /usr/local/go/bin/go test -timeout 30s -run ^TestDrawTestSuite$ -testify.m ^(TestModuleAccountFailure)$ github.com/lcnem/jpyx/x/cdp/keeper

--- FAIL: TestDrawTestSuite (0.01s)
    --- FAIL: TestDrawTestSuite/TestModuleAccountFailure (0.01s)
        /home/yasunori_matsuoka/github.com/lcnem/jpyx/x/cdp/keeper/draw_test.go:185: 
            	Error Trace:	draw_test.go:185
            	Error:      	func (assert.PanicTestFunc)(0x1458b20) should panic
            	            		Panic value:	<nil>
            	Test:       	TestDrawTestSuite/TestModuleAccountFailure
FAIL
exit status 1
FAIL	github.com/lcnem/jpyx/x/cdp/keeper	0.045s
```

テスト自体はシンプルに、suite.Panicsの中で呼ばれている関数の処理で、Panicが生じればPass、そうでなければFailと思っているのですが、そこで呼び出されている以下関数の実行状況をデバッグしたところ、

https://github.com/lcnem/jpyx/blob/ae2faae26866b90cf6191dcfa2713bb3855e0d21/x/cdp/keeper/draw.go#L74

以下のreturnの箇所でnilが返ってきており、テストの実装から推測される期待値(=Panicが起こる)とは異なる状況が発生していました。

https://github.com/lcnem/jpyx/blob/ae2faae26866b90cf6191dcfa2713bb3855e0d21/x/cdp/keeper/draw.go#L169

ただ、テストの条件を正とみなして実装自体を修正すべきなのか、テストの方を修正すべきなのか、判断に迷っているという状況で、相談させてください。