### PR TITLE
fix: unpack-auction

### DIFF
--- a/x/auction/genesis_test.go
+++ b/x/auction/genesis_test.go
@@ -76,7 +76,8 @@ func TestInitGenesis(t *testing.T) {
 		})
 		i := 0
 		keeper.IterateAuctions(ctx, func(a auctiontypes.Auction) bool {
-			require.Equal(t, gs.Auctions[i], a)
+			unpacked, _ := auctiontypes.UnpackAuction(gs.Auctions[i])
+			require.Equal(t, unpacked, a)
 			i++
 			return false
 		})


### PR DESCRIPTION
テスト自体はまだ落ちるが、
*codectypes.Anyとauctiontypes.Auctionの比較をしていて落ちたのは治した

auctiontypes.Auctionとauctiontypes.Auctionの比較でフィールドが違うので引き続き落ちています