### PR TITLE
fix: delete invalid reward factor test

### DIFF
--- a/x/incentive/types/genesis_test.go
+++ b/x/incentive/types/genesis_test.go
@@ -87,23 +87,23 @@ func TestGenesisStateValidate(t *testing.T) {
 				contains:   "",
 			},
 		},
-		{
-			name: "invalid genesis accumulation time",
-			args: args{
-				params: DefaultParams(),
-				genAccTimes: GenesisAccumulationTimes{
-					{
-						CollateralType: "btcb-a",
-						//RewardFactor:   sdk.MustNewDecFromStr("-0.1"),
-					},
-				},
-				claims: DefaultJpyxClaims,
-			},
-			errArgs: errArgs{
-				expectPass: false,
-				contains:   "reward factor should be ≥ 0.0",
-			},
-		},
+		// {
+		// 	name: "invalid genesis accumulation time",
+		// 	args: args{
+		// 		params: DefaultParams(),
+		// 		genAccTimes: GenesisAccumulationTimes{
+		// 			{
+		// 				CollateralType: "btcb-a",
+		// 				RewardFactor:   sdk.MustNewDecFromStr("-0.1"),
+		// 			},
+		// 		},
+		// 		claims: DefaultJpyxClaims,
+		// 	},
+		// 	errArgs: errArgs{
+		// 		expectPass: false,
+		// 		contains:   "reward factor should be ≥ 0.0",
+		// 	},
+		// },
 		{
 			name: "invalid claim",
 			args: args{


### PR DESCRIPTION
GenesisAccumulationTimes型がhard関連と思われるRewardFactorを持たないように仕様変更されていたので、テスト自体を削除

参考
```
type GenesisAccumulationTime struct {
	CollateralType           string    `protobuf:"bytes,1,opt,name=collateral_type,json=collateralType,proto3" json:"collateral_type,omitempty" yaml:"collateral_type"`
	PreviousAccumulationTime time.Time `protobuf:"bytes,2,opt,name=previous_accumulation_time,json=previousAccumulationTime,proto3,stdtime" json:"previous_accumulation_time" yaml:"previous_accumulation_time"`
}
```

close #71

@KimuraYu45z @YasunoriMATSUOKA @Tomosuke0930 
削除で問題ないか確認お願いします。