### PR TITLE
feat: faucet backend api and reverse proxy

### DIFF
--- a/faucet/deploy.sh
+++ b/faucet/deploy.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+# mkdir ~/faucet
+# cd ~/faucet
+# curl -O https://raw.githubusercontent.com/lcnem/jpyx/faucet/deploy.sh
+docker-compose down
+curl -O https://raw.githubusercontent.com/lcnem/jpyx/faucet/docker-compose.yml
+curl -O https://raw.githubusercontent.com/lcnem/jpyx/nginx.conf
+docker cp $(docker ps -qf "name=jpyxd"):/usr/bin/jpyxd ~/faucet/jpyxd
+docker-compose up -d

--- a/faucet/docker-compose.yml
+++ b/faucet/docker-compose.yml
@@ -1,0 +1,46 @@
+version: "3"
+
+services:
+  faucet-ubtc:
+    container_name: faucet-ubtc
+    image: ghcr.io/tendermint/faucet
+    volumes:
+      - ~/faucet/jpyxd:/usr/local/bin/jpyxd
+      - ~/.jpyx:/root/.jpyx
+    command: faucet --cli-name jpyxd --denoms ubtc --keyring-backend test --account-name faucet --port 7000 --credit-amount=100 --max-credit=99
+    # ports:
+    #   - 7000:7000
+    network_mode: host
+    restart: always
+  faucet-ujsmn:
+    container_name: faucet-ujsmn
+    image: ghcr.io/tendermint/faucet
+    volumes:
+      - ~/faucet/jpyxd:/usr/local/bin/jpyxd
+      - ~/.jpyx:/root/.jpyx
+    command: faucet --cli-name jpyxd --denoms ujsmn --keyring-backend test --account-name faucet --port 7002 --credit-amount=2000000 --max-credit=1999999
+    # ports:
+    #   - 7002:7002
+    network_mode: host
+    restart: always
+  faucet-jpyx:
+    container_name: faucet-jpyx
+    image: ghcr.io/tendermint/faucet
+    volumes:
+      - ~/faucet/jpyxd:/usr/local/bin/jpyxd
+      - ~/.jpyx:/root/.jpyx
+    command: faucet --cli-name jpyxd --denoms ujsmn --keyring-backend test --account-name faucet --port 7004 --credit-amount=10 --max-credit=9
+    # ports:
+    #   - 7004:7004
+    network_mode: host
+    restart: always
+  nginx:
+    image: nginx
+    volumes:
+      - ~/faucet/nginx.conf:/etc/nginx/nginx.conf
+    # ports:
+    #   - 8000:8000
+    #   - 8002:8002
+    #   - 8004:8004
+    network_mode: host
+    restart: always

--- a/faucet/nginx.conf
+++ b/faucet/nginx.conf
@@ -1,0 +1,65 @@
+events {
+}
+
+http {
+  server {
+    listen 8000;
+    server_name localhost;
+    charset UTF-8;
+
+    location / {
+      proxy_http_version 1.1;
+      proxy_pass http://localhost:7000;
+
+      if ($request_method = 'OPTIONS') {
+        add_header Access-Control-Allow-Origin '*';
+        add_header Access-Control-Allow-Methods 'GET, POST, PUT, DELETE';
+        add_header Access-Control-Allow-Headers 'Origin, Authorization, Accept, Content-Type';
+        # add_header Access-Control-Max-Age 3600;
+        add_header Content-Type 'text/plain charset=UTF-8';
+        add_header Content-Length 0;
+        return 204;
+      }
+    }
+  }
+  server {
+    listen 8002;
+    server_name localhost;
+    charset UTF-8;
+
+    location / {
+      proxy_http_version 1.1;
+      proxy_pass http://localhost:7002;
+
+      if ($request_method = 'OPTIONS') {
+        add_header Access-Control-Allow-Origin '*';
+        add_header Access-Control-Allow-Methods 'GET, POST, PUT, DELETE';
+        add_header Access-Control-Allow-Headers 'Origin, Authorization, Accept, Content-Type';
+        # add_header Access-Control-Max-Age 3600;
+        add_header Content-Type 'text/plain charset=UTF-8';
+        add_header Content-Length 0;
+        return 204;
+      }
+    }
+  }
+  server {
+    listen 8004;
+    server_name localhost;
+    charset UTF-8;
+
+    location / {
+      proxy_http_version 1.1;
+      proxy_pass http://localhost:7004;
+
+      if ($request_method = 'OPTIONS') {
+        add_header Access-Control-Allow-Origin '*';
+        add_header Access-Control-Allow-Methods 'GET, POST, PUT, DELETE';
+        add_header Access-Control-Allow-Headers 'Origin, Authorization, Accept, Content-Type';
+        # add_header Access-Control-Max-Age 3600;
+        add_header Content-Type 'text/plain charset=UTF-8';
+        add_header Content-Length 0;
+        return 204;
+      }
+    }
+  }
+}


### PR DESCRIPTION
@KimuraYu45z cc: @taro04 @Senna46 
レビューお願いします。関連プルリクもセットの内容になります。

FaucetのバックエンドAPIをdenom毎に分割して、denom毎に引き出し制限数量等変えて動作させるための修正と、botanyからjpyxレポジトリに移すという修正です。
バックエンドの修正内容はこれで完了となりますのでこちらのプルリクはレビューお願いします。

フロントエンド側の修正は以下プルリクで作業中で未完ですが、明日完了くらいの見込みです。フロントエンド側の修正もマージでき次第、改めて諸々デプロイします。動作確認取れたら最後にbotany側に残ったFaucetの実装を消します。

関連プルリク
https://github.com/lcnem/telescope/pull/166
https://github.com/lcnem/botany/pull/122