### PR TITLE
fix: GetAuction return err

### DIFF
--- a/x/auction/keeper/grpc_query_auction.go
+++ b/x/auction/keeper/grpc_query_auction.go
@@ -47,9 +47,9 @@ func (k Keeper) Auction(c context.Context, req *types.QueryGetAuctionRequest) (*
 
 	ctx := sdk.UnwrapSDKContext(c)
 
-	auction, err := k.GetAuction(ctx, req.Id)
+	auction, found := k.GetAuction(ctx, req.Id)
 
-	if err {
+	if !found {
 		return nil, status.Error(codes.NotFound, "not found")
 	}
 	auctionAny, _ := codectypes.NewAnyWithValue(auction)

--- a/x/auction/keeper/keeper.go
+++ b/x/auction/keeper/keeper.go
@@ -111,16 +111,23 @@ func (k Keeper) GetAuction(ctx sdk.Context, auctionID uint64) (types.Auction, bo
 	store := prefix.NewStore(ctx.KVStore(k.storeKey), types.KeyPrefix(types.AuctionKey))
 	bz := store.Get(types.GetAuctionKey(auctionID))
 	if bz == nil {
-		return auction, false
+		// return auction, false
+		return auction, true
 	}
 
 	var auctionAny codectypes.Any
 	auctionAny.Unmarshal(bz)
 	auction, err := types.UnpackAuction(&auctionAny)
+
+	fmt.Printf("UnpackAuction res, %s\n", auction)
+	fmt.Printf("UnpackAuction err, %s\n", err)
+
 	if err != nil {
-		return nil, false
+		// return nil, false
+		return nil, true
 	}
-	return auction, true
+	// return auction, true
+	return auction, false
 }
 
 // DeleteAuction removes an auction from the store, and any indexes.

--- a/x/auction/keeper/keeper.go
+++ b/x/auction/keeper/keeper.go
@@ -111,8 +111,7 @@ func (k Keeper) GetAuction(ctx sdk.Context, auctionID uint64) (types.Auction, bo
 	store := prefix.NewStore(ctx.KVStore(k.storeKey), types.KeyPrefix(types.AuctionKey))
 	bz := store.Get(types.GetAuctionKey(auctionID))
 	if bz == nil {
-		// return auction, false
-		return auction, true
+		return auction, false
 	}
 
 	var auctionAny codectypes.Any
@@ -123,11 +122,9 @@ func (k Keeper) GetAuction(ctx sdk.Context, auctionID uint64) (types.Auction, bo
 	fmt.Printf("UnpackAuction err, %s\n", err)
 
 	if err != nil {
-		// return nil, false
-		return nil, true
+		return nil, false
 	}
-	// return auction, true
-	return auction, false
+	return auction, true
 }
 
 // DeleteAuction removes an auction from the store, and any indexes.

--- a/x/auction/keeper/keeper.go
+++ b/x/auction/keeper/keeper.go
@@ -117,10 +117,6 @@ func (k Keeper) GetAuction(ctx sdk.Context, auctionID uint64) (types.Auction, bo
 	var auctionAny codectypes.Any
 	auctionAny.Unmarshal(bz)
 	auction, err := types.UnpackAuction(&auctionAny)
-
-	fmt.Printf("UnpackAuction res, %s\n", auction)
-	fmt.Printf("UnpackAuction err, %s\n", err)
-
 	if err != nil {
 		return nil, false
 	}


### PR DESCRIPTION
@KimuraYu45z @YasunoriMATSUOKA 
x/cdp/keeper/cdps.go　なども参考に確認したところ、x/auction/keeper/grpc_query_auction.go　のGetAuctionが最後まで通ったときに返すのが、trueなのが原因で、"not found"エラーになっている気がするのこのPRで一度確認させてください。